### PR TITLE
Feature/upload progress

### DIFF
--- a/src/Xablu.WebApiClient/HttpContentExtensions/ProgressStreamContent.cs
+++ b/src/Xablu.WebApiClient/HttpContentExtensions/ProgressStreamContent.cs
@@ -1,0 +1,250 @@
+﻿using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Xablu.WebApiClient
+{
+	public delegate void ProgressDelegate(long bytes, long totalBytes, long totalBytesExpected);
+
+	/// <summary>
+	/// This class helps to track upload and download progress. It is a slight modified implementation of https://github.com/paulcbetts/ModernHttpClient/blob/64b36bb670ae655455477b766c60683ca0cf3a3e/src/ModernHttpClient/ProgressStreamContent.cs
+	/// </summary>
+	public class ProgressStreamContent : StreamContent
+	{
+		public ProgressStreamContent(HttpContentHeaders headers, Stream stream, CancellationToken token) : this(new ProgressStream(stream, token))
+		{
+			foreach (var h in headers)
+			{
+				this.Headers.Add(h.Key, h.Value);
+			}
+		}
+
+		public ProgressStreamContent(Stream stream, CancellationToken token) : this(new ProgressStream(stream, token)) { }
+
+		public ProgressStreamContent(Stream stream, int bufferSize) : this(new ProgressStream(stream, CancellationToken.None), bufferSize) { }
+
+		ProgressStreamContent(ProgressStream stream) : base(stream)
+		{
+			init(stream);
+		}
+
+		ProgressStreamContent(ProgressStream stream, int bufferSize) : base(stream, bufferSize)
+		{
+			init(stream);
+		}
+
+		void init(ProgressStream stream)
+		{
+			stream.ReadCallback = readBytes;
+
+			Progress = delegate { };
+		}
+
+		void reset()
+		{
+			_totalBytes = 0L;
+		}
+
+		long _totalBytes;
+		long _totalBytesExpected = -1;
+
+		void readBytes(long bytes)
+		{
+			if (_totalBytesExpected == -1)
+				_totalBytesExpected = Headers.ContentLength ?? -1;
+
+			long computedLength;
+			if (_totalBytesExpected == -1 && TryComputeLength(out computedLength))
+				_totalBytesExpected = computedLength == 0 ? -1 : computedLength;
+
+			// If less than zero still then change to -1
+			_totalBytesExpected = Math.Max(-1, _totalBytesExpected);
+			_totalBytes += bytes;
+
+			Progress(bytes, _totalBytes, _totalBytesExpected);
+		}
+
+		ProgressDelegate _progress;
+		public ProgressDelegate Progress
+		{
+			get
+			{
+				return _progress;
+			}
+			set
+			{
+				if (value == null) _progress = delegate { };
+				else _progress = value;
+			}
+		}
+
+		protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
+		{
+			reset();
+			return base.SerializeToStreamAsync(stream, context);
+		}
+
+		protected override bool TryComputeLength(out long length)
+		{
+			var result = base.TryComputeLength(out length);
+			_totalBytesExpected = length;
+			return result;
+		}
+
+		class ProgressStream : Stream
+		{
+			CancellationToken token;
+
+			public ProgressStream(Stream stream, CancellationToken token)
+			{
+				ParentStream = stream;
+				this.token = token;
+
+				ReadCallback = delegate { };
+				WriteCallback = delegate { };
+			}
+
+			public Action<long> ReadCallback
+			{
+				get;
+				set;
+			}
+
+			public Action<long> WriteCallback
+			{
+				get;
+				set;
+			}
+
+			public Stream ParentStream
+			{
+				get;
+				private set;
+			}
+
+			public override bool CanRead
+			{
+				get
+				{
+					return ParentStream.CanRead;
+				}
+			}
+
+			public override bool CanSeek
+			{
+				get
+				{
+					return ParentStream.CanSeek;
+				}
+			}
+
+			public override bool CanWrite
+			{
+				get
+				{
+					return ParentStream.CanWrite;
+				}
+			}
+
+			public override bool CanTimeout
+			{
+				get
+				{
+					return ParentStream.CanTimeout;
+				}
+			}
+
+			public override long Length
+			{
+				get
+				{
+					return ParentStream.Length;
+				}
+			}
+
+			public override void Flush()
+			{
+				ParentStream.Flush();
+			}
+
+			public override Task FlushAsync(CancellationToken cancellationToken)
+			{
+				return ParentStream.FlushAsync(cancellationToken);
+			}
+
+			public override long Position
+			{
+				get
+				{
+					return ParentStream.Position;
+				}
+				set
+				{
+					ParentStream.Position = value;
+				}
+			}
+
+			public override int Read(byte[] buffer, int offset, int count)
+			{
+				token.ThrowIfCancellationRequested();
+
+				var readCount = ParentStream.Read(buffer, offset, count);
+				ReadCallback(readCount);
+				return readCount;
+			}
+
+			public override long Seek(long offset, SeekOrigin origin)
+			{
+				token.ThrowIfCancellationRequested();
+				return ParentStream.Seek(offset, origin);
+			}
+
+			public override void SetLength(long value)
+			{
+				token.ThrowIfCancellationRequested();
+				ParentStream.SetLength(value);
+			}
+
+			public override void Write(byte[] buffer, int offset, int count)
+			{
+				token.ThrowIfCancellationRequested();
+				ParentStream.Write(buffer, offset, count);
+				WriteCallback(count);
+			}
+
+			public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+			{
+				token.ThrowIfCancellationRequested();
+				var linked = CancellationTokenSource.CreateLinkedTokenSource(token, cancellationToken);
+
+				var readCount = await ParentStream.ReadAsync(buffer, offset, count, linked.Token);
+
+				ReadCallback(readCount);
+				return readCount;
+			}
+
+			public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+			{
+				token.ThrowIfCancellationRequested();
+
+				var linked = CancellationTokenSource.CreateLinkedTokenSource(token, cancellationToken);
+				var task = ParentStream.WriteAsync(buffer, offset, count, linked.Token);
+
+				WriteCallback(count);
+				return task;
+			}
+
+			protected override void Dispose(bool disposing)
+			{
+				if (disposing)
+				{
+					ParentStream.Dispose();
+				}
+			}
+		}
+	}
+}

--- a/src/Xablu.WebApiClient/HttpExtensions/WebApiClientProgressExtensions.cs
+++ b/src/Xablu.WebApiClient/HttpExtensions/WebApiClientProgressExtensions.cs
@@ -1,0 +1,32 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Fusillade;
+using Xablu.WebApiClient.HttpExtensions;
+
+namespace Xablu.WebApiClient
+{
+	public static class WebApiClientProgressExtension
+	{
+		public static async Task<TResult> PostAsync<TContent, TResult>(this WebApiClient webApiClient, Priority priority, string path, TContent content = default(TContent), ProgressDelegate progressDelegate = null, IHttpContentResolver contentResolver = null)
+		{
+			var httpClient = webApiClient.GetWebApiClient(priority);
+
+			webApiClient.SetHttpRequestHeaders(httpClient);
+
+			var httpContent = webApiClient.ResolveHttpContent(content);
+
+			var stream = await httpContent.ReadAsStreamAsync();
+			var progressContent = new ProgressStreamContent(httpContent.Headers, stream, CancellationToken.None);
+			progressContent.Progress = progressDelegate;
+
+			var response = await httpClient
+				.PostAsync(path, progressContent)
+				.ConfigureAwait(false);
+
+			if (!await response.EnsureSuccessStatusCodeAsync())
+				return default(TResult);
+
+			return await webApiClient.HttpResponseResolver.ResolveHttpResponseAsync<TResult>(response);
+		}
+	}
+}

--- a/src/Xablu.WebApiClient/WebApiClient.cs
+++ b/src/Xablu.WebApiClient/WebApiClient.cs
@@ -148,33 +148,7 @@ namespace Xablu.WebApiClient
 
             SetHttpRequestHeaders(httpClient);
 
-            HttpContent httpContent = null;
-
-            if (content != null)
-            {
-                if (content is HttpContent)
-                {
-                    httpContent = content as HttpContent;
-                }
-                else
-                {
-                    if (contentResolver != null)
-                    {
-                        httpContent = contentResolver.ResolveHttpContent(content);
-                    }
-                    else
-                    {
-                        if (content is Dictionary<string, string>)
-                        {
-                            httpContent = new DictionaryContentResolver().ResolveHttpContent(content as Dictionary<string, string>);
-                        }
-                        else
-                        {
-                            httpContent = HttpContentResolver.ResolveHttpContent(content);
-                        }
-                    }
-                }
-            }
+            HttpContent httpContent = ResolveHttpContent(content);
             var response = await httpClient
                 .PostAsync(path, httpContent)
                 .ConfigureAwait(false);
@@ -222,7 +196,39 @@ namespace Xablu.WebApiClient
             return await HttpResponseResolver.ResolveHttpResponseAsync<TResult>(response);
         }
 
-        private HttpClient GetWebApiClient(Priority prioriy)
+        internal HttpContent ResolveHttpContent<TContent>(TContent content, IHttpContentResolver contentResolver = null)
+        {
+        	HttpContent httpContent = null;
+
+        	if (content != null)
+        	{
+        		if (content is HttpContent)
+        		{
+        			httpContent = content as HttpContent;
+        		}
+        		else
+        		{
+        			if (contentResolver != null)
+        			{
+        				httpContent = contentResolver.ResolveHttpContent(content);
+        			}
+        			else
+        			{
+        				if (content is Dictionary<string, string>)
+        				{
+        					httpContent = new DictionaryContentResolver().ResolveHttpContent(content as Dictionary<string, string>);
+        				}
+        				else
+        				{
+        					httpContent = HttpContentResolver.ResolveHttpContent(content);
+        				}
+        			}
+        		}
+        	}
+            return httpContent;
+        }
+
+        internal HttpClient GetWebApiClient(Priority prioriy)
         {
             switch (prioriy)
             {
@@ -239,7 +245,7 @@ namespace Xablu.WebApiClient
             }
         }
 
-        void SetHttpRequestHeaders(HttpClient client)
+        internal void SetHttpRequestHeaders(HttpClient client)
         {
             client.DefaultRequestHeaders.Clear();
             client.DefaultRequestHeaders.Accept.Clear();

--- a/src/Xablu.WebApiClient/Xablu.WebApiClient.csproj
+++ b/src/Xablu.WebApiClient/Xablu.WebApiClient.csproj
@@ -48,6 +48,8 @@
     <Compile Include="Resolvers\SimpleJsonContentResolver.cs" />
     <Compile Include="Resolvers\SimpleJsonResponseResolver.cs" />
     <Compile Include="WebApiClient.cs" />
+    <Compile Include="HttpContentExtensions\ProgressStreamContent.cs" />
+    <Compile Include="HttpExtensions\WebApiClientProgressExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Fusillade, Version=0.7.0.0, Culture=neutral, processorArchitecture=MSIL">
@@ -89,6 +91,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="HttpContentExtensions\" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
Added upload progress for post functionality in an extension method. The ProgressStreamContent.cs does also support download progress but that is not included in this PR and can be added later. Note that this only works with WebApiClient.cs for now.

The way it works is as following: the httpContent can be read as a stream. By passing in this stream to the ProgressStreamContent and adding the correct headers the same httpcontent can be send as a stream and the bytes that are send by using that request can be counted because its a stream.
 
The implementation of the  ProgressStreamContent is based on the one from ModernHttpClient.
Example of usage would be:
```c
async Task myCall()
{
         await apiClient.PostAsync<MultipartFormDataContent, byte[]>(Priority.UserInitiated, uri.Resolve(), content, HandleUploadProgress).ConfigureAwait(false);
}  

void HandleUploadProgress(long bytes, long totalBytes, long totalBytesExpected)
{
            float percentage = ((float)totalBytes / (float)totalBytesExpected) * 100f;

            UpdateThings(percentage);
}
```