### PR TITLE
Implementation of the `RestApiClientOptions` class

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,35 +18,43 @@ The Xablu WebApiClient is a C# HTTP library which aims to simplify consuming of 
 
 Create a new singleton of WebApiClient and use it to do REST operations.
 ```c#
-var webApiClient = new WebApiClient("http://baseurl.com/");
+var restApiClient = new RestApiClient("http://baseurl.com/");
 ```
 
 ### MvvmCross
 
-If you want to use the standard HTTP client handlers, just register `IWebApiClient` with a base url. You can set the type of native handler in your csproj settings.
+If you want to use the standard HTTP client handlers, just register `IRestApiClient` with a base url. You can set the type of native handler in your csproj settings.
 
 ```c#
-Mvx.RegisterSingleton<IWebApiClient>(new WebApiClient(Constants.ApiBaseUrl));
+Mvx.RegisterSingleton<IRestApiClient>(new RestApiClient(Constants.ApiBaseUrl));
 ```
 
 When using custom HTTP handler, register a custom iOS Handler
 
 ```c#
-Mvx.RegisterSingleton<IWebApiClient>(new WebApiClient(Constants.ApiBaseUrl, () => new NSUrlSessionHandler()));
+var options = new RestApiClientOptions(Constants.ApiBaseUrl) 
+{
+    DefaultHttpMessageHandler = () => new NSUrlSessionHandler();
+};
+Mvx.RegisterSingleton<IRestApiClient>(new RestApiClient(options));
 ```
 
 Register the custom handler in Android
 
 ```c#
-Mvx.RegisterSingleton<IWebApiClient>(new WebApiClient(Constants.ApiBaseUrl, () => new AndroidClientHandler()));
+var options = new RestApiClientOptions(Constants.ApiBaseUrl) 
+{
+    DefaultHttpMessageHandler = () => new AndroidClientHandler();
+};
+Mvx.RegisterSingleton<IRestApiClient>(new RestApiClient(options));
 ```
 
 Create a client to handle Http traffic
 
 ```c#
-public class AuthenticationClient : BaseClient, IAuthenticationClient
+public class AuthenticationClient : IAuthenticationClient
 {
-   public AuthenticationClient(IWebApiClient apiClient) : base(apiClient)
+   public AuthenticationClient(IRestApiClient apiClient) : base(apiClient)
    {
    }
 

--- a/Xablu.WebApiClient/IRestApiClient.cs
+++ b/Xablu.WebApiClient/IRestApiClient.cs
@@ -8,10 +8,7 @@ namespace Xablu.WebApiClient
 {
     public interface IRestApiClient : IDisposable
     {
-        string DefaultAcceptHeader { get; set; }
         string AuthorizeToken { get; set; }
-
-        void SetBaseAddress(string apiBaseAddress);
 
         Task<IRestApiResult<TResult>> GetAsync<TResult>(
             Priority priority,

--- a/Xablu.WebApiClient/RestApiClientOptions.cs
+++ b/Xablu.WebApiClient/RestApiClientOptions.cs
@@ -13,9 +13,61 @@ namespace Xablu.WebApiClient
             ApiBaseAddress = apiBaseAddress;
         }
 
+        /// <summary>
+        /// Gets the base address of the API to which the <see cref="RestApiClient"/> will send the HTTP requests.
+        /// </summary>
+        /// <remarks>
+        /// The base address must only contain the HTTP-scheme (http or https) and the domain / ip-address to connect to. 
+        /// An example could be "https://www.xablu.com". The base address will be appended in front of the 'path' value which
+        /// is supplied with every HTTP request. 
+        /// </remarks>
         public string ApiBaseAddress { get; }
+
+        /// <summary>
+        /// Gets or sets a delegate which will instantiate an instance of <see cref="HttpMessageHandler"/> class used to process the HTTP requests.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="RestApiClient"/> will (lazily) create an instance of the <see cref="HttpClient"/> object for each of the different priorities.
+        /// The delegate supplied to the <see cref="DefaultHttpMessageHandler"/> property is called to supply the <see cref="HttpClient"/> with an implementation
+        /// of the <see cref="HttpMessageHandler"/> class. 
+        /// 
+        /// You can supply a different delegate to create a platform specific implementation of the <see cref="HttpMessageHander"/> class. For example you might want 
+        /// to supply one of the following:
+        /// 
+        /// <code>
+        /// // To use the NSUrlSessionHandler (on iOS devices) use:
+        /// () => new NSUrlSessionHandler();
+        /// 
+        /// // To use the AndroidClientHandler (on Android devices) use:
+        /// () => new AndroidClientHandler();
+        /// </code> 
+        /// 
+        /// By default the delegate will create an instance of the <see cref="HttpClientHandler"/> (standard .NET implementation).   
+        /// </remarks>
         public Func<HttpMessageHandler> DefaultHttpMessageHandler { get; set; } = () => new HttpClientHandler { AutomaticDecompression = System.Net.DecompressionMethods.GZip };
-        public IList<KeyValuePair<string, string>> DefaultHeaders { get; set; } = new List<KeyValuePair<string, string>> { { "Accept", "application/json" }, { "Accept-Enconding", "gzip" } };
+
+        /// <summary>
+        /// Gets or sets a list of default headers which will be used with every HTTP request made by the <see cref="RestApiClient"/>.
+        /// </summary>
+        /// <remarks>
+        /// The headers specified in this list will be added to every HTTP request made by the <see cref="RestApiClient"/>. The following headers
+        /// are already pre-configured:
+        /// <list type="table">  
+        ///    <listheader>  
+        ///        <term>Key</term>  
+        ///        <description>Value</description>  
+        ///    </listheader>  
+        ///    <item>  
+        ///        <term>Accept</term>  
+        ///        <description>application/json</description>  
+        ///    </item>  
+        ///    <item>  
+        ///        <term>Accept-Encoding</term>  
+        ///        <description>gzip</description>  
+        ///    </item>  
+        /// </list>  
+        /// </remarks>
+        public IList<KeyValuePair<string, string>> DefaultHeaders { get; set; } = new List<KeyValuePair<string, string>> { { "Accept", "application/json" }, { "Accept-Encoding", "gzip" } };
 
         /// <summary>
         /// Gets or sets the default implementation of the <see cref="IHttpContentResolver"/> interface associated with the WebApiClient.

--- a/Xablu.WebApiClient/RestApiClientOptions.cs
+++ b/Xablu.WebApiClient/RestApiClientOptions.cs
@@ -1,0 +1,54 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+using Xablu.WebApiClient.Resolvers;
+using System.Net.Http;
+using System;
+
+namespace Xablu.WebApiClient
+{
+    public class RestApiClientOptions
+    {
+        public RestApiClientOptions(string apiBaseAddress)
+        {
+            ApiBaseAddress = apiBaseAddress;
+        }
+
+        public string ApiBaseAddress { get; }
+        public Func<HttpMessageHandler> DefaultHttpMessageHandler { get; set; } = () => new HttpClientHandler { AutomaticDecompression = System.Net.DecompressionMethods.GZip };
+        public IList<KeyValuePair<string, string>> DefaultHeaders { get; set; } = new List<KeyValuePair<string, string>> { { "Accept", "application/json" }, { "Accept-Enconding", "gzip" } };
+
+        /// <summary>
+        /// Gets or sets the default implementation of the <see cref="IHttpContentResolver"/> interface associated with the WebApiClient.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="IHttpContentResolver"/> implementation is responsible for serializing content which needs to be send to the server
+        /// using a HTTP POST, PUT or PATCH request.
+        /// 
+        /// This property can be used to override the default <see cref="IHttpContentResolver"/> that is used by the <see cref="RestApiClient"/>.
+        /// If no other value is supplied the <see cref="RestApiClient"/> by default uses the <see cref="SimpleJsonContentResolver"/>. This resolver will
+        /// try to serialize the content to a JSON message and returns the proper <see cref="System.Net.Http.HttpContent"/> instance.
+        /// 
+        /// NOTE: this property is not thread safe! You should only set this property when initializing the <see cref="RestApiClient"/>. If
+        /// you want to override the <see cref="IHttpContentResolver"/> for a particular request you should supply the appropiate <see cref="IHttpContentResolver"/>
+        /// with one of the <see cref="GetAsync"/>, <see cref="PostAsync"/>, <see cref="PutAsync"/>, <see cref="PatchAsync"/> or <see cref="DeleteAsync"/> methods.  
+        /// </remarks>
+        public IHttpContentResolver DefaultContentResolver { get; set; } = new SimpleJsonContentResolver(new JsonSerializer());
+
+        /// <summary>
+        /// Gets or sets the default implementation of the <see cref="IHttpResponseResolver"/> interface associated with the RestApiClient.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="IHttpResponseResolver"/> implementation is responsible for deserialising the <see cref="System.Net.Http.HttpResponseMessage"/>
+        /// into the required result object.
+        /// 
+        /// This property can be used to override the default <see cref="IHttpResponseResolver"/> that is used by the <see cref="RestApiClient"/>.
+        /// If no other value is supplied the <see cref="RestApiClient"/> by default uses the <see cref="SimpleJsonResponseResolver"/>. This resolver will
+        /// assumes the response is a JSON message and tries to deserialize it into the required result object.
+        /// 
+        /// NOTE: this property is not thread safe! You should only set this property when initializing the <see cref="RestApiClient"/>. If
+        /// you want to override the <see cref="IHttpResponseResolver"/> for a particular request you should supply the appropiate <see cref="IHttpContentResolver"/>
+        /// with one of the <see cref="GetAsync"/>, <see cref="PostAsync"/>, <see cref="PutAsync"/>, <see cref="PatchAsync"/> or <see cref="DeleteAsync"/> methods.  
+        /// </remarks>
+        public IHttpResponseResolver DefaultResponseResolver { get; set; } = new SimpleJsonResponseResolver(new JsonSerializer());
+    }
+}

--- a/Xablu.WebApiClient/RestApiProgressClient.cs
+++ b/Xablu.WebApiClient/RestApiProgressClient.cs
@@ -12,23 +12,13 @@ namespace Xablu.WebApiClient
     public class RestApiProgressClient
         : RestApiClient
     {
-        public RestApiProgressClient()
-            : base()
-        {
-        }
-
         public RestApiProgressClient(string apiBaseAddress)
             : base(apiBaseAddress)
         {
         }
 
-        public RestApiProgressClient(Func<HttpMessageHandler> handler)
-            : base(handler)
-        {
-        }
-
-        public RestApiProgressClient(string apiBaseAddress, Func<HttpMessageHandler> handler)
-            : base(apiBaseAddress, handler)
+        public RestApiProgressClient(RestApiClientOptions options)
+            : base(options)
         {
         }
 


### PR DESCRIPTION
Instead of using several constructor overloads we now have one overload accepting an instance of the `RestApiClientOptions` class. This class can be used to supply additional configuration to the `RestApiClient` (it also contains all the default implementations).

I also updated the documentation and provided XML docs descriptions for each of the properties in the `RestApiClientOptions` class.