### PR TITLE
Add GraphQL support to WebApiClient

### DIFF
--- a/TestApp/TestApp/Services/IGitHubApi.cs
+++ b/TestApp/TestApp/Services/IGitHubApi.cs
@@ -1,0 +1,11 @@
+using System;
+using Xablu.WebApiClient.Attributes;
+
+namespace TestApp.Services
+{
+    [GraphQLEndpoint("/graphql")]
+    public interface IGitHubApi
+    {
+        // we could of course have some REST endpoints here and use Refit!
+    }
+}

--- a/TestApp/TestApp/Services/IStarwarsApi.cs
+++ b/TestApp/TestApp/Services/IStarwarsApi.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Refit;

--- a/TestApp/TestApp/Views/MainPage.xaml.cs
+++ b/TestApp/TestApp/Views/MainPage.xaml.cs
@@ -11,6 +11,8 @@ using GraphQL.Common.Request;
 using GraphQL.Common.Response;
 using Newtonsoft.Json;
 using System.Linq;
+using Xablu.WebApiClient;
+using TestApp.Services;
 
 namespace TestApp.Views
 {
@@ -38,22 +40,17 @@ namespace TestApp.Views
 
         private async Task GraphqlAsync()
         {
-            var dict = new Dictionary<string, string>() {
-                { "Authorization","Bearer " }
+            var defaultHeaders = new Dictionary<string, string>
+            {
+                ["User-Agent"] = "LukasThijs",
+                ["Authorization"] = "Bearer "
             };
-
-
-            var graphqlTest = new GraphQLService("https://api.github.com/graphql", null);
-            graphqlTest.Client.DefaultRequestHeaders.Add("User-Agent", "LukasThijs");
-            graphqlTest.Client.DefaultRequestHeaders.Add("Authorization", "Bearer ");
-
-            var responseModel = new UserResponseModel() { User = new User() };
-            var request = new Request<UserResponseModel>(null, responseModel, new[] { "(login: LukasThijs)" });
-            var response = await graphqlTest.Client.SendQueryAsync(request);
-
+            var webApiClient = WebApiClientFactory.Get<IGitHubApi>("https://api.github.com", false, () => new SampleHttpClientHandler(), defaultHeaders);
+            var request = new Request<UserResponseModel>(null, new UserResponseModel(), new[] { "(login: LukasThijs)" });
+              
+            // TODO: Handle the result!
+            await webApiClient.SendQueryAsync(request);
         }
-
-
 
 
         public async Task NavigateFromMenu(int id)

--- a/src/Xablu.WebApiClient/Attributes/GraphQLEndpointAttribute.cs
+++ b/src/Xablu.WebApiClient/Attributes/GraphQLEndpointAttribute.cs
@@ -1,0 +1,14 @@
+using System;
+namespace Xablu.WebApiClient.Attributes
+{ 
+    [AttributeUsage(AttributeTargets.Interface, AllowMultiple = true)]
+    public class GraphQLEndpointAttribute : Attribute
+    {
+        public GraphQLEndpointAttribute(string path)
+        {
+            Path = path;
+        }
+
+        public string Path { get; private set; }
+    }
+}

--- a/src/Xablu.WebApiClient/Client/IRefitService.cs
+++ b/src/Xablu.WebApiClient/Client/IRefitService.cs
@@ -1,10 +1,10 @@
 using System;
+using Xablu.WebApiClient.Enums;
+
 namespace Xablu.WebApiClient.Client
 {
     public interface IRefitService<T>
     {
-        T Speculative { get; }
-        T UserInitiated { get; }
-        T Background { get; }
+        T GetByPriority(Priority priority);
     }
 }

--- a/src/Xablu.WebApiClient/IWebApiClient.cs
+++ b/src/Xablu.WebApiClient/IWebApiClient.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Xablu.WebApiClient.Enums;
+using Xablu.WebApiClient.Services.GraphQL;
 
 namespace Xablu.WebApiClient
 {
@@ -14,5 +16,11 @@ namespace Xablu.WebApiClient
 
         Task Call(Func<T, Task> operation, RequestOptions options);
         Task<TResult> Call<TResult>(Func<T, Task<TResult>> operation, RequestOptions options);
+
+        Task SendQueryAsync<TModel>(Request<TModel> request, CancellationToken cancellationToken = default(CancellationToken))
+            where TModel : class;
+
+        Task SendMutationAsync<TModel>(Request<TModel> request, CancellationToken cancellationToken = default(CancellationToken))
+            where TModel : class;
     }
 }

--- a/src/Xablu.WebApiClient/Services/GraphQL/GraphQLService.cs
+++ b/src/Xablu.WebApiClient/Services/GraphQL/GraphQLService.cs
@@ -1,61 +1,72 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
-using System.Threading.Tasks;
+using Fusillade;
 using GraphQL.Client.Http;
-using GraphQL.Common.Request;
 
 namespace Xablu.WebApiClient.Services.GraphQL
 {
-    public class GraphQLService
+    public class GraphQLService : IGraphQLService
     {
-        private GraphQLHttpClientOptions _graphQLClientOptions;
-        private Dictionary<string, string> _headers;
+        private readonly Lazy<GraphQLHttpClient> _background;
+        private readonly Lazy<GraphQLHttpClient> _userInitiated;
+        private readonly Lazy<GraphQLHttpClient> _speculative;
 
-        public GraphQLService(string baseUrl = "", Func<DelegatingHandler> delegatingHandler = null, Dictionary<string, string> headers = null)
+        public string BaseUrl { get; private set; }
+
+        public GraphQLService(string apiBaseAddress, bool autoRedirectRequests, Func<DelegatingHandler> delegatingHandler, IDictionary<string, string> defaultHeaders)
         {
-            if (delegatingHandler != null)
+            BaseUrl = apiBaseAddress;
+
+            Func<HttpMessageHandler, GraphQLHttpClient> createClient = messageHandler =>
             {
-                _graphQLClientOptions = new GraphQLHttpClientOptions
+                HttpMessageHandler handler;
+
+                if (delegatingHandler != null)
                 {
-                    HttpMessageHandler = delegatingHandler?.Invoke()
-                };
-            }
-            BaseURL = baseUrl;
-            Headers = headers;
-
-        }
-
-        public GraphQLHttpClient Client { get; set; }
-
-        public string BaseURL { get; set; }
-
-        public Dictionary<string, string> Headers
-        {
-            get { return _headers; }
-            set
-            {
-                _headers = value;
-                InitClient(BaseURL, value);
-            }
-        }
-
-
-        private void InitClient(string baseUrl, Dictionary<string, string> headers = null)
-        {
-            Client = new GraphQLHttpClient(baseUrl);
-
-            if (_graphQLClientOptions != null)
-            {
-                Client.Options = _graphQLClientOptions;
-            }
-
-            if (headers != null)
-            {
-                foreach (KeyValuePair<string, string> header in headers)
-                {
-                    Client.DefaultRequestHeaders.Add(header.Key, header.Value);
+                    var delegatingHandlerInstance = delegatingHandler.Invoke();
+                    delegatingHandlerInstance.InnerHandler = messageHandler;
+                    handler = delegatingHandlerInstance;
                 }
+                else
+                {
+                    handler = messageHandler;
+                }
+
+                // note: the string parameter is just a placeholder here
+                var client = new GraphQLHttpClient(apiBaseAddress);
+
+                client.Options = new GraphQLHttpClientOptions { HttpMessageHandler = handler };
+                
+                if (defaultHeaders != default)
+                {
+                    foreach (var header in defaultHeaders)
+                    {
+                        client.DefaultRequestHeaders.Add(header.Key, header.Value);
+                    }
+                }
+
+                return client;
+            };
+
+            _background = new Lazy<GraphQLHttpClient>(() => createClient(NetCache.Background));
+
+            _userInitiated = new Lazy<GraphQLHttpClient>(() => createClient(NetCache.UserInitiated));
+
+            _speculative = new Lazy<GraphQLHttpClient>(() => createClient(NetCache.Speculative));
+        }
+
+        public GraphQLHttpClient GetByPriority(Enums.Priority priority)
+        {
+            switch (priority)
+            {
+                case Enums.Priority.Background:
+                    return _background.Value;
+                case Enums.Priority.Speculative:
+                    return _speculative.Value;
+                case Enums.Priority.UserInitiated:
+                default:
+                    return _userInitiated.Value;
             }
         }
     }

--- a/src/Xablu.WebApiClient/Services/GraphQL/IGraphQLService.cs
+++ b/src/Xablu.WebApiClient/Services/GraphQL/IGraphQLService.cs
@@ -1,0 +1,12 @@
+using GraphQL.Client.Http;
+using Xablu.WebApiClient.Enums;
+
+namespace Xablu.WebApiClient.Services.GraphQL
+{
+    public interface IGraphQLService
+    {
+        string BaseUrl { get; }
+
+        GraphQLHttpClient GetByPriority(Priority priority);        
+    }
+}

--- a/src/Xablu.WebApiClient/WebApiClient.cs
+++ b/src/Xablu.WebApiClient/WebApiClient.cs
@@ -32,7 +32,7 @@ namespace Xablu.WebApiClient
 
         public async Task Call(Func<T, Task> operation, Priority priority, int retryCount, Func<Exception, bool> shouldRetry, int timeout)
         {
-            var service = GetServiceByPriority(priority);
+            var service = _refitService.GetByPriority(priority);
 
             var policy = GetWrappedPolicy(retryCount, shouldRetry, timeout);
 
@@ -46,7 +46,7 @@ namespace Xablu.WebApiClient
 
         public async Task<TResult> Call<TResult>(Func<T, Task<TResult>> operation, Priority priority, int retryCount, Func<Exception, bool> shouldRetry, int timeout)
         {
-            var service = GetServiceByPriority(priority);
+            var service = _refitService.GetByPriority(priority);
 
             var policy = GetWrappedPolicy<TResult>(retryCount, shouldRetry, timeout);
 
@@ -68,17 +68,8 @@ namespace Xablu.WebApiClient
             return Call<TResult>(operation, options.Priority, options.RetryCount, options.ShouldRetry, options.Timeout);
         }
 
-        private T GetServiceByPriority(Priority priority)
         {
-            switch(priority)
             {
-                case Priority.Background:
-                    return _refitService.Background;
-                case Priority.Speculative:
-                    return _refitService.Speculative;
-                case Priority.UserInitiated:
-                default:
-                    return _refitService.UserInitiated;
             }
         }
 

--- a/src/Xablu.WebApiClient/WebApiClientFactory.cs
+++ b/src/Xablu.WebApiClient/WebApiClientFactory.cs
@@ -1,16 +1,24 @@
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using Xablu.WebApiClient.Client;
+using Xablu.WebApiClient.Services.GraphQL;
 
 namespace Xablu.WebApiClient
 {
     public static class WebApiClientFactory
     {
-        public static IWebApiClient<T> Get<T>(string baseUrl, bool autoRedirectRequests = true, Func<DelegatingHandler> delegatingHandler = null)
+        public static IWebApiClient<T> Get<T>(
+            string baseUrl,
+            bool autoRedirectRequests = true,
+            Func<DelegatingHandler> delegatingHandler = default,
+            IDictionary<string, string> defaultHeaders = default)
+            where T : class
         {
-            var refitService = new RefitService<T>(baseUrl, autoRedirectRequests, delegatingHandler);
+            var refitService = new RefitService<T>(baseUrl, autoRedirectRequests, delegatingHandler, defaultHeaders);
+            var graphQLService = new GraphQLService(baseUrl, autoRedirectRequests, delegatingHandler, defaultHeaders);
 
-            return new WebApiClient<T>(refitService);
+            return new WebApiClient<T>(refitService, graphQLService);
         }
     }
 }


### PR DESCRIPTION
Partially addresses #43. We aim to provide a single API to developers. This PR adds (initial) GraphQL support to the class `WebApiClient`.

A few highlights:
- We previously discussed about removing the generic `T` (the refit interface) from all places, but we can't easily change it for a dynamic Type (like `typeof(T)`) because in that case it's necessary to perform some nasty reflection operations and casting.
- The proposed approach is then to extend the use of the interface to GraphQL. Developers will always need to include an interface and an attribute on top of it's definition signaling the endpoint name. For example:

```c#
[GraphQLEndpoint("/graphql")]
public interface IGitHubApi
{
    // we could of course have some REST endpoints here and use Refit!
}
```

This is 100% compatible with our way to do REST requests with Refit.

- WebApiClient now exposes two methods for sending queries and mutations.
- Fusillade support for GraphQL calls was added 
- This PR doesn't include support for Polly 